### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm i @fastify/kafka
 ### Usage
 
 ```js
-const crypto = require('crypto')
+const crypto = require('node:crypto')
 const fastify = require('fastify')()
 const group = crypto.randomBytes(20).toString('hex')
 

--- a/examples/basic.js
+++ b/examples/basic.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const crypto = require('crypto')
+const crypto = require('node:crypto')
 const fastify = require('fastify')({
   logger: {
     level: 'debug'

--- a/examples/multiple-consumers.js
+++ b/examples/multiple-consumers.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const crypto = require('crypto')
+const crypto = require('node:crypto')
 const fastifyKafka = require('..')
 const fastify = require('fastify')
 

--- a/lib/consumer.js
+++ b/lib/consumer.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const EE = require('events').EventEmitter
-const inherits = require('util').inherits
+const EE = require('node:events').EventEmitter
+const inherits = require('node:util').inherits
 const Kafka = require('node-rdkafka')
 
 function Consumer (opts, log, next, topicConf, metadataOptions) {

--- a/lib/producer.js
+++ b/lib/producer.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const EE = require('events').EventEmitter
-const inherits = require('util').inherits
+const EE = require('node:events').EventEmitter
+const inherits = require('node:util').inherits
 const Kafka = require('node-rdkafka')
 
 function Producer (opts, log, next, topicConf, metadataOptions) {

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const crypto = require('crypto')
+const crypto = require('node:crypto')
 
 module.exports.getDefaultOptions = function getDefaultOptions () {
   return {


### PR DESCRIPTION
See https://github.com/fastify/fastify-static/pull/407

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
