### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ fastify
   .register(require('@fastify/kafka'), {
     producer: {
       'metadata.broker.list': '127.0.0.1:9092',
-      'group.id': group,
       'fetch.wait.max.ms': 10,
       'fetch.error.backoff.ms': 50,
       'dr_cb': true


### PR DESCRIPTION
The producer config does not have a 'group.id' option. Just removing it from the example so people don't run into issues.