### PR TITLE
refactor(types): migrate from tsd to tstyche

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint:fix": "eslint --fix",
     "test": "npm run test:unit && npm run test:typescript",
     "test:unit": "c8 --100 node --test",
-    "test:typescript": "tsd"
+    "test:typescript": "tstyche"
   },
   "repository": {
     "type": "git",
@@ -69,10 +69,7 @@
     "c8": "^11.0.0",
     "fastify": "^5.0.0",
     "neostandard": "^0.13.0",
-    "tsd": "^0.33.0"
-  },
-  "tsd": {
-    "directory": "test"
+    "tstyche": "^7.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/types/index.tst.ts
+++ b/types/index.tst.ts
@@ -1,9 +1,8 @@
 import Fastify, { FastifyKafkaConsumer, FastifyKafkaProducer, Kafka } from 'fastify'
-import { expectAssignable } from 'tsd'
+import { expect } from 'tstyche'
 import fastifyKafka from '..'
 
 const app = Fastify()
-
 app.register(fastifyKafka, {
   producer: {
     'metadata.broker.list': '127.0.0.1:9092',
@@ -27,9 +26,9 @@ app.register(fastifyKafka, {
 })
 
 // Check whether all properties are merged successfully or not
-expectAssignable<Kafka>(app.kafka)
-expectAssignable<FastifyKafkaProducer | undefined>(app.kafka.producer)
-expectAssignable<FastifyKafkaConsumer | undefined>(app.kafka.consumer)
-expectAssignable<Function>(app.kafka.push)
-expectAssignable<Function>(app.kafka.consume)
-expectAssignable<Function>(app.kafka.subscribe)
+expect(app.kafka).type.toBeAssignableTo<Kafka>()
+expect(app.kafka.producer).type.toBeAssignableTo<FastifyKafkaProducer | undefined>()
+expect(app.kafka.consumer).type.toBeAssignableTo<FastifyKafkaConsumer | undefined>()
+expect(app.kafka.push).type.toBeAssignableTo<Function>()
+expect(app.kafka.consume).type.toBeAssignableTo<Function>()
+expect(app.kafka.subscribe).type.toBeAssignableTo<Function>()

--- a/types/index.tst.ts
+++ b/types/index.tst.ts
@@ -26,9 +26,9 @@ app.register(fastifyKafka, {
 })
 
 // Check whether all properties are merged successfully or not
-expect(app.kafka).type.toBeAssignableTo<Kafka>()
-expect(app.kafka.producer).type.toBeAssignableTo<FastifyKafkaProducer | undefined>()
-expect(app.kafka.consumer).type.toBeAssignableTo<FastifyKafkaConsumer | undefined>()
+expect(app.kafka).type.toBe<Kafka>()
+expect(app.kafka.producer).type.toBe<FastifyKafkaProducer | undefined>()
+expect(app.kafka.consumer).type.toBe<FastifyKafkaConsumer | undefined>()
 expect(app.kafka.push).type.toBeAssignableTo<Function>()
 expect(app.kafka.consume).type.toBeAssignableTo<Function>()
 expect(app.kafka.subscribe).type.toBeAssignableTo<Function>()


### PR DESCRIPTION
Proposal:

- migrate from `tsd` to `tstyche`

PR of Reference: 
  - https://github.com/fastify/fastify/pull/6532
  - https://github.com/fastify/fastify/pull/6525

While waiting for this PR:https://github.com/fastify/fastify-kafka/pull/166  to be merged, updating the test for types 
