### PR TITLE
docs: fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ This module exposes the following APIs:
 
 ## Acknowledgments
 
-This project is kindly sponsored by:
-- [LetzDoIt](https://www.letzdoitapp.com/)
+Past sponsors:
+- LetzDoIt
 
 ## License
 


### PR DESCRIPTION
Fixes 404s, 3xx redirections, and missing fragments in the documentation. Part of general link cleanup being tracked in https://github.com/fastify/accept-negotiator/pull/71